### PR TITLE
fix: :lipstick: prevent layout shift with scrollbar

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,6 +1,8 @@
 import { AppProps } from 'next/app'
 import { ChakraProvider } from '@chakra-ui/react'
 import theme from '../theme'
+// fix for jumping scrollbar
+import '../styles/global.css'
 
 function MyApp({ Component, pageProps }: AppProps) {
   return (

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,0 +1,6 @@
+@media screen and (min-width: 830px) {
+  html {
+      margin-left: calc(100vw - 100%);
+      margin-right: 0;
+  }
+}

--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -1,5 +1,6 @@
 import { extendTheme, ThemeConfig } from '@chakra-ui/react'
 import { createBreakpoints } from '@chakra-ui/theme-tools'
+import { mode } from '@chakra-ui/theme-tools'
 
 const fonts = { mono: `'Menlo', monospace` }
 
@@ -22,6 +23,14 @@ const theme = extendTheme({
   fonts,
   breakpoints,
   config,
+  // set html background to same color as component bg
+  styles: {
+    global: (props: any) => ({
+      html: {
+        bg: mode('#f7fafc', '#171923')(props),
+      },
+    }),
+  },
 })
 
 export default theme


### PR DESCRIPTION
Adds invisible margin on left when scrollbar appears so content doesn't get pushed to left

Close #11